### PR TITLE
isCanisterRunning detection fixed

### DIFF
--- a/dfxservice.go
+++ b/dfxservice.go
@@ -125,11 +125,11 @@ func (s *DFXService) isCanisterRunning() (bool, error) {
 		s.log.WithError(err).Errorln("Could not determine canister status:", output)
 		return false, err
 	}
-	if !strings.HasPrefix(output, "Canister "+s.config.CanisterName+"'s status is ") {
+	if !strings.HasPrefix(output, "Canister status call result for " + s.config.CanisterName) {
 		s.log.WithError(err).Errorln("Could not determine canister status:", output)
 		return false, fmt.Errorf("Could not determine canister status: %v", output)
 	}
-	isRunning := strings.HasPrefix(output, "Canister "+s.config.CanisterName+"'s status is Running.")
+	isRunning := strings.HasPrefix(output, "Status: Running")
 	return isRunning, nil
 }
 


### PR DESCRIPTION
`dfx canister status` command output has the following format:

```
➜  weather_oracle git:(master) ✗ dfx canister status weather_oracle
Canister status call result for weather_oracle.
Status: Running
Controller: rwlgt-iiaaa-aaaaa-aaaaa-cai
Memory allocation: 0
Compute allocation: 0
Freezing threshold: 2_592_000
Memory Size: Nat(404999)
Balance: 4_000_000_000_000 Cycles
Module hash: 0xd52f6f15691fd9f2db3ec756d1faa1209d4590bfa1b18d734a765c313e054966
```

So we should search for different string patterns.